### PR TITLE
Update cmake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.10.2)
 project(Venoge VERSION 0.0.0 LANGUAGES CXX)
 
 # Get the correct target locations among all platforms


### PR DESCRIPTION
Ubuntu 18.04 ships with cmake 3.10.2. I would say it makes sense to sync on it.

@sansuiso Is that an issue? Why did you set 3.11?